### PR TITLE
Add more parametrize tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     rev: 4.3.21-2
     hooks:
       - id: isort
+        additional_dependencies: [toml]
   - repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 100
+indent = '    '
 known_third_party = ["pytest"]
+known_first_party = ["sandbox_pytest"]
 
 [tool.pytest.ini_options]
 testpaths = ["test", "tests"]

--- a/tests/test_sandbox_pytest/test_math_ops.py
+++ b/tests/test_sandbox_pytest/test_math_ops.py
@@ -1,14 +1,17 @@
+from typing import Sequence
+
 import pytest
+
 from sandbox_pytest.math_ops import add, div, multiply, sub
 
 
 @pytest.fixture()
-def test_ints_tuple():
+def test_ints_tuple() -> Sequence[int]:
     return 1, 2, 3, 4
 
 
 @pytest.fixture()
-def test_list() -> None:
+def test_list() -> Sequence[int]:
     return [1, 2, 3, 4]
 
 
@@ -79,6 +82,22 @@ def test_multiply_ints() -> None:
     assert multiply(1, 2, 3, 4) == 24
 
 
+@pytest.mark.parametrize(
+    "add_args, add_exp_result",
+    [((10, 5), 50), ([100, 100, 0, 5], 0), ((500, 100, 300), 15_000_000)],
+)
+def test_multiply_params_iterables(add_args, add_exp_result) -> None:
+    assert multiply(*add_args) == add_exp_result
+
+
+@pytest.mark.parametrize(
+    "add_args, add_exp_result",
+    [((10, 5), 50), ([100, 100, 0, 5], 0), ((500, 100, 300), 15_000_000)],
+)
+def test_multiply_params_ints(add_args, add_exp_result) -> None:
+    assert multiply(add_args) == add_exp_result
+
+
 @pytest.mark.tuple
 def test_div_tuple() -> None:
     assert div((4, 2, 1)) == 2
@@ -90,3 +109,17 @@ def test_div_list() -> None:
 
 def test_div_ints() -> None:
     assert div(4, 2, 1) == 2
+
+
+@pytest.mark.parametrize(
+    "add_args, add_exp_result", [((10, 5), 2), ([100, 100, 1], 1), ((500, 250), 2)],
+)
+def test_div_params_iterables(add_args, add_exp_result) -> None:
+    assert div(*add_args) == add_exp_result
+
+
+@pytest.mark.parametrize(
+    "add_args, add_exp_result", [((10, 5), 2), ([100, 100, 1], 1), ((500, 250), 2)],
+)
+def test_div_params_ints(add_args, add_exp_result) -> None:
+    assert div(add_args) == add_exp_result


### PR DESCRIPTION
This PR adds more parametrized tests for multiply and div functions.  Additionally, I added the toml dependency for the isort pre-commit hook so that it works properly.  I also added library as known_first_party isort config.